### PR TITLE
Harmonize primus/ws logic and expose send()

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ Client.prototype.connectDelta = function(hostname, callback, onConnect, onDiscon
     if (onConnect) {
       signalKStream.on('connect', onConnect(skConnection));
     } else {
-      signalKStream.on('connect', function() { signalKStream.write(sub); };
+      signalKStream.on('connect', function() { signalKStream.write(sub); });
     }
   } else {
     debug("Using ws");


### PR DESCRIPTION
Primus/ws logic branches should now behave the same.
Furthermore the returned connection and the one passed to onConnect expose send(),
which JSON.stringifys the parameter and sends it to the server. This allows sendings subscriptions
for example.
