### PR TITLE
Fix discovery and add discoveryAvailable()

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,10 @@ Client.prototype.get = function(path, hostname, port) {
       (this.port || port) + path);
 }
 
+Client.prototype.discoveryAvailable = function() {
+  return moduleAvailable('md' + 'ns')
+}
+
 Client.prototype.startDiscovery = function() {
   debug('startDiscovery');
   var that = this;
@@ -332,6 +336,14 @@ function isDelta(msg) {
 
 function isHello(msg) {
   return typeof msg.version != "undefined"
+}
+
+function moduleAvailable(name) {
+  try {
+    require.resolve(name);
+    return true;
+  } catch(e) {}
+  return false;
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -79,12 +79,12 @@ Client.prototype.connect = function(options) {
   var hostname = this.hostname;
   var port = this.port;
 
-  if (options) {
+  if(options) {
     hostname = options.hostname || hostname;
     port = options.port || port;
   }
 
-  if (hostname && port) {
+  if(hostname && port) {
     return this.connectDelta(
       options.hostname + ":" + options.port,
       options.onData,
@@ -187,7 +187,7 @@ Client.prototype.connectDeltaByUrl = function(wsUrl, callback, onConnect, onDisc
     hostname: this.hostname
   };
 
-  if (typeof Primus != 'undefined') {
+  if(typeof Primus != 'undefined') {
     debug("Using Primus");
     var primus = Primus.connect(wsUrl, {
       reconnect: {
@@ -202,7 +202,7 @@ Client.prototype.connectDeltaByUrl = function(wsUrl, callback, onConnect, onDisc
       primus.end();
       debug('Disconnected');
     };
-    if (onConnect) {
+    if(onConnect) {
       primus.on('open', onConnect.bind(this, skConnection));
     } else {
       primus.on('open', function() {
@@ -221,7 +221,7 @@ Client.prototype.connectDeltaByUrl = function(wsUrl, callback, onConnect, onDisc
     };
     connection.onopen = function(msg) {
       debug("open");
-      if (onConnect) {
+      if(onConnect) {
         onConnect(skConnection)
       } else {
         skConnection.send(sub);
@@ -229,7 +229,7 @@ Client.prototype.connectDeltaByUrl = function(wsUrl, callback, onConnect, onDisc
     };
     connection.onerror = function(error) {
       debug("error:" + error);
-      if (onError) {
+      if(onError) {
         onError(error)
       }
     };
@@ -238,7 +238,7 @@ Client.prototype.connectDeltaByUrl = function(wsUrl, callback, onConnect, onDisc
     };
     connection.onclose = function(event) {
       debug("close:" + event);
-      if (onClose) {
+      if(onClose) {
         onClose(event)
       }
     };
@@ -280,10 +280,10 @@ Client.prototype.getSelfMatcher = function() {
     var selfData = result.body;
     var selfId = selfData.mmsi || selfData.uuid;
 
-    if (selfId) {
+    if(selfId) {
       var selfContext = 'vessels.' + selfId;
       return function(delta) {
-        return (delta.context === 'self' || delta.context === 'vessels.self' ||
+        return(delta.context === 'self' || delta.context === 'vessels.self' ||
           delta.context === selfContext);
       };
     } else {
@@ -299,13 +299,13 @@ Client.prototype.getMeta = function(prefix, path) {
 }
 
 function convertUpdateToHumanUnits(update) {
-  if (update.values) {
+  if(update.values) {
     update.values.forEach(convertPathValueToHumanUnits)
   }
 }
 
 function convertPathValueToHumanUnits(pathValue) {
-  if (signalkSchema.metadata[pathValue.path] && conversions[signalkSchema.metadata[pathValue.path].units]) {
+  if(signalkSchema.metadata[pathValue.path] && conversions[signalkSchema.metadata[pathValue.path].units]) {
     pathValue.value = conversions[signalkSchema.metadata[pathValue.path].units].convert(pathValue.value);
     pathValue.units = conversions[signalkSchema.metadata[pathValue.path].units].to;
   }


### PR DESCRIPTION
- Fix discovery by using the simplest ResolverSequence: just mdns.rst.DNSServiceResolve
that populates the host and port in the service record. The default sequence was causing errors on both OS X and Jessie Lite (RPi).
- Add discoveryAvailable() method.
- Refactor so that discoverAndConnect uses startDiscovery/stopDiscovery.
- Change startDiscovery so that it returns a Promise that resolves
with the first discovery.
- Change the returned discovery to include host, port, httpResponse and
service.