### PR TITLE
fix: improve error handling in WebSocket

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,11 @@ Client.prototype.connectDeltaByUrl = function(wsUrl, callback, onConnect, onDisc
       }
     };
     connection.onmessage = function(msg) {
-      callback(JSON.parse(msg.data));
+      try {
+        callback(JSON.parse(msg.data));
+      } catch(e) {
+        console.error(e)
+      }
     };
     connection.onclose = function(event) {
       debug("close:" + event);


### PR DESCRIPTION
Handle JSON parsing errors gracefully: do not throw errors, just log the error.