### PR TITLE
Add Promise based connectP method

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,8 +99,8 @@ Client.prototype.apiGet = function(path) {
 }
 
 Client.prototype.get = function(path, hostname, port) {
-  return agent('GET', 'http://' + (this.hostname || hostname) + ':' +
-      (this.port || port) + path);
+  return agent('GET', 'http://' + (hostname || this.hostname) + ':' +
+      (port || this.port) + path);
 }
 
 Client.prototype.discoveryAvailable = function() {


### PR DESCRIPTION
As the discovery process is asynchronous by nature add a Promise-based method for
connecting. The Promise is resolved with a connected ws connection or rejected
in case something goes wrong in http or ws connections.