### PR TITLE
fix mmsi

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,6 +319,8 @@ Client.prototype.getSelfMatcher = function() {
     var selfId = selfData.mmsi || selfData.uuid;
 
     if(selfId) {
+      if (selfId === selfData.mmsi)	
+        selfId = 'urn:mrn:imo:mmsi:' + selfId;       
       var selfContext = 'vessels.' + selfId;
       return function(delta) {
         return(delta.context === 'self' || delta.context === 'vessels.self' ||


### PR DESCRIPTION
Sailgauge does use getSelfMatcher.
Everything works fine when you use a setting script with "uuid": "urn:mrn:signalk:uuid:123456789".
It doesn't work when you use a setting script with "uuid": "urn:mrn:imo:mmsi:123456789". (signalk-schema/samples/0183-RMC-full.json)
This does fix this issue. But I don't know if it is the best solution.