### PR TITLE
Added link to signalk-client-angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ function connectDelta(host, thisCallback, onConnect, onDisconnect) {
   );
 }
 ```
+
+
+## Other Signal K Clients:
+**Angular:**
+Signal K client for the Angular framework
+[signalk-client-angular](https://github.com/panaaj/signalk-client-angular)
+


### PR DESCRIPTION
Added link to signalk-client-angular, a port of the signalk-js-client for the Angular framework.