### PR TITLE
Switch to a pure-JS mDNS implementation for the Discovery process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Signal K JS SDK
+# Signal K JS Client
 
-[![Build Status](https://travis-ci.org/SignalK/signalk-js-client.svg?branch=fabdrol-sdk)](https://travis-ci.org/SignalK/signalk-js-client)
+[![Build Status](https://travis-ci.org/SignalK/signalk-js-client.svg)](https://travis-ci.org/SignalK/signalk-js-client)
 
 > A Javascript SDK for Signal K clients. Provides various abstract interfaces for discovering (via optional mDNS) the Signal K server and communication via WebSocket & REST. Aims to implement all major APIs in the most recent Signal K version(s).
 
@@ -14,8 +14,8 @@ This is not yet published on Github. If you'd like to use an early version, use 
 
 ### BASIC USAGE
 ```javascript
-import Client, { Discovery } from '@signalk/signalk-js-sdk'
-import mdns from 'mdns'
+import Client, { Discovery } from '@signalk/client'
+import Bonjour from 'bonjour'
 
 let client = null
 
@@ -41,8 +41,9 @@ client = new Client({
 })
 
 // Discover client using mDNS
-// Params: mdns lib, search time
-const discovery = new Discovery(mdns, 60000)
+// Params: bonjour lib, search time
+const bonjour = Bonjour()
+const discovery = new Discovery(bonjour, 60000)
 
 // Timeout fires when search time is up and no servers were found
 discovery.on('timeout', () => console.log('No SK servers found'))
@@ -55,6 +56,7 @@ discovery.on('found', server => {
       useAuthentication: true,
       reconnect: true,
       autoConnect: true,
+      notifications: false,
       username: 'sdk@decipher.industries',
       password: 'signalk'
     })
@@ -131,20 +133,7 @@ Signal K client for the Angular framework
 [signalk-client-angular](https://github.com/panaaj/signalk-client-angular)
 
 
-### PRE-1.0 RELEASE CHECKLIST
-- [x] mDNS server discovery
-- [x] Security/authentication (REST) support
-- [x] Basic notifications/alarms support
-- [x] Access Request mechanism (responding to requests, as a special case of notification)
-- [x] Security/authentication (WS) support (relies on request/response)
-- [x] PUT requests via request/response over WS
-- [x] Access Request mechanism (basic requesting)
-- [x] PUT requests via REST
-- [x] Move mDNS stack into a separate class
-- [ ] Write comprehensive README of supported options, methods, examples, etc
-
-
-### FUTURE RELEASES
+### WISHLIST
 - [ ] Expand device access mechanism into its own EventEmitter
 - [ ] Master/slave detection during discovery, with correct selection. Should emit an event if multiple mains+masters are found
 - [ ] Dynamic REST API based on `signalk-schema`, auto-generated tests for each path so client can be used to test-drive servers
@@ -152,11 +141,12 @@ Signal K client for the Angular framework
 - [ ] History API support
 - [ ] Port codebase & tests to Typescript
 - [ ] Add an option to spawn a `WebWorker` for each `Connection`, offloading server comms to a different thread
+- [x] Switch mDNS to bonjour (pure JS) implementation
+- [ ] Add a React hook
 
 
 ### NOTES
 - mDNS advert should advertise if server supports TLS
-- `PUT requests via REST` have been implemented, but don't have a valid test yet. Need to figure out how to test this
 - Node SK server responds with "Request updated" for access request responses. This is incorrect per spec
 - Node SK server paths for access requests repsponses are not correct to spec (i.e. no /signalk/v1 prefix)
 - ~~Security is implemented, but the token type is currently hardcoded to `JWT` if no `token.type` is returned by a SK server. IMHO that default should be `Bearer`. See issue https://github.com/SignalK/signalk-server-node/issues/715 & PR https://github.com/SignalK/specification/pull/535~~

--- a/dist/bonjour.js
+++ b/dist/bonjour.js
@@ -1,0 +1,21 @@
+"use strict";
+
+var _bonjour = _interopRequireDefault(require("bonjour"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const bonjour = (0, _bonjour.default)();
+const browser = bonjour.find({
+  type: 'signalk-http'
+});
+console.log(Object.keys(bonjour));
+browser.on('up', service => {
+  console.log(JSON.stringify(service, null, 2));
+  browser.stop();
+  process.exit();
+});
+browser.start();
+setTimeout(() => {
+  browser.stop();
+  process.exit();
+}, 10000);

--- a/dist/lib/connection.js
+++ b/dist/lib/connection.js
@@ -281,12 +281,12 @@ class Connection extends _eventemitter.default {
       }
     }
 
-    const isObj = data && typeof data === 'object'; // Add token to data IF authenticated
+    const isObj = data && typeof data === 'object'; // FIXME: this shouldn't be required as per discussion about security.
+    // Add token to data IF authenticated
     // https://signalk.org/specification/1.3.0/doc/security.html#other-clients
-
-    if (isObj && this.useAuthentication === true && this._authenticated === true) {
-      data.token = String(this._token.token);
-    }
+    // if (isObj && this.useAuthentication === true && this._authenticated === true) {
+    //   data.token = String(this._token.token)
+    // }
 
     try {
       if (isObj) {
@@ -297,7 +297,8 @@ class Connection extends _eventemitter.default {
     }
 
     debug("Sending data to socket: ".concat(data));
-    this.socket.send(data);
+    const result = this.socket.send(data);
+    return Promise.resolve(result);
   }
 
   fetch(path, opts) {

--- a/dist/lib/discovery.js
+++ b/dist/lib/discovery.js
@@ -73,18 +73,22 @@ class SKServer {
 exports.SKServer = SKServer;
 
 class Discovery extends _eventemitter.default {
-  constructor(mDNS) {
+  constructor(bonjour) {
     let timeout = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 60000;
     super();
+    const props = ['_server', '_registry'].join(',');
 
-    if (!mDNS || typeof mDNS !== 'object' || !mDNS.hasOwnProperty('createBrowser')) {
-      throw new Error('Invalid mDNS provider given');
+    if (!bonjour || typeof bonjour !== 'object' || Object.keys(bonjour).join(',') !== props) {
+      throw new Error('Invalid mDNS provider');
     }
 
     this.found = [];
-    const browser = mDNS.createBrowser(mDNS.tcp('_signalk-http'));
-    browser.on('serviceUp', ad => {
-      const service = _objectSpread({}, ad.txtRecord, {
+    const browser = bonjour.find({
+      type: 'signalk-http'
+    });
+    browser.on('up', ad => {
+      const service = _objectSpread({}, ad.txt, {
+        name: ad.name || '',
         hostname: ad.host || '',
         port: parseInt(ad.port, 10)
       });

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "@babel/core": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
     "@babel/register": "^7.0.0",
+    "bonjour": "^3.5.0",
     "casper-chai": "^0.3.0",
     "chai": "^4.1.0",
     "freeport-promise": "^1.1.0",
-    "mdns": "^2.4.0",
     "mocha": "^6.0.2",
     "signalk-server": "^1.13.0"
   },

--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -275,11 +275,12 @@ export default class Connection extends EventEmitter {
 
     const isObj = (data && typeof data === 'object')
 
+    // FIXME: this shouldn't be required as per discussion about security.
     // Add token to data IF authenticated
     // https://signalk.org/specification/1.3.0/doc/security.html#other-clients
-    if (isObj && this.useAuthentication === true && this._authenticated === true) {
-      data.token = String(this._token.token)
-    }
+    // if (isObj && this.useAuthentication === true && this._authenticated === true) {
+    //   data.token = String(this._token.token)
+    // }
 
     try {
       if (isObj) {
@@ -290,7 +291,8 @@ export default class Connection extends EventEmitter {
     }
 
     debug(`Sending data to socket: ${data}`)
-    this.socket.send(data)
+    const result = this.socket.send(data)
+    return Promise.resolve(result)
   }
 
   fetch (path, opts) {

--- a/src/lib/discovery.js
+++ b/src/lib/discovery.js
@@ -57,19 +57,22 @@ export class SKServer {
 }
 
 export default class Discovery extends EventEmitter {
-  constructor (mDNS, timeout = 60000) {
+  constructor (bonjour, timeout = 60000) {
     super()
 
-    if (!mDNS || typeof mDNS !== 'object' || !mDNS.hasOwnProperty('createBrowser')) {
-      throw new Error('Invalid mDNS provider given')
+    const props = [ '_server', '_registry' ].join(',')
+
+    if (!bonjour || typeof bonjour !== 'object' || Object.keys(bonjour).join(',') !== props) {
+      throw new Error('Invalid mDNS provider')
     }
 
     this.found = []
-    const browser = mDNS.createBrowser(mDNS.tcp('_signalk-http'))
+    const browser = bonjour.find({ type: 'signalk-http' })
 
-    browser.on('serviceUp', ad => {
+    browser.on('up', ad => {
       const service = {
-        ...ad.txtRecord,
+        ...ad.txt,
+        name: ad.name || '',
         hostname: ad.host || '',
         port: parseInt(ad.port, 10)
       }

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ import Client, {
   PERMISSIONS_READONLY
 } from '../src'
 
-import mdns from 'mdns'
+import Bonjour from 'bonjour'
 import { assert } from 'chai'
 import { v4 as uuid } from 'uuid'
 import Server from 'signalk-server'
@@ -399,7 +399,8 @@ describe('Signal K SDK', () => {
   describe('mDNS server discovery', () => {
     it('... Emits an event when a Signal K host is found', done => {
       let found = 0
-      const discovery = new Discovery(mdns, 10000)
+      const bonjour = Bonjour()
+      const discovery = new Discovery(bonjour, 10000)
 
       discovery.once('found', server => {
         found += 1


### PR DESCRIPTION
This PR fixes feature request https://github.com/SignalK/signalk-js-client/issues/46 by @tkurki, and removes the build step that was required for `node-mdns`.