### PR TITLE
feature: Allows SSL connection to server with self-signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ client = new Client({
   hostname: 'hq.decipher.digital',
   port: 3000,
   useTLS: true,
+  rejectUnauthorized: false, // Optional, set to false only if the server has a self-signed certificate
   useAuthentication: true,
   reconnect: true,
   autoConnect: false,

--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -193,7 +193,7 @@ export default class Connection extends EventEmitter {
   }
 
   initiateSocket () {
-    this.socket = new WebSocket(this.wsURI)
+    this.socket = new WebSocket(this.wsURI, (this.options.rejectUnauthorized === false) ? {rejectUnauthorized: false} : {})
     this.socket.addEventListener('message', this.onWSMessage)
     this.socket.addEventListener('open', this.onWSOpen)
     this.socket.addEventListener('error', this.onWSError)


### PR DESCRIPTION
With nodejs, `signalk-js-client` refuses to establish a connection to a server with a self-signed certificate.
I have added an optional parameter `rejectUnauthorized`, if false create the WebSocket with the option rejectUnauthorized: false that invalidate  certificate CA checking.
This PR is identical to cancelled #63
