### PR TITLE
fix: make use without subscribe=none and subscriptions possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,19 @@ let client = null
 client = new Client({
   hostname: 'demo.signalk.org',
   port: 80,
-  useTLS: true,
+  useTLS: false,
   reconnect: true,
   autoConnect: false
+})
+
+// Instantiate client whithout uri subscribe parameter for compatibility with iKommunicate
+client = new Client({
+  hostname: 'demo.signalk.org',
+  port: 80,
+  useTLS: false,
+  reconnect: true,
+  autoConnect: false,
+  noUriSubscribeParameter: true // optional if Signal K server not support /signalk/v1/stream?subscribe=none
 })
 
 // Instantiate client with authentication

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Javascript SDK for Signal K clients. Provides various abstract interfaces for discovering (via optional mDNS) the Signal K server and communication via WebSocket & REST. Aims to implement all major APIs in the most recent Signal K version(s)",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --require @babel/register --exit",
+    "test": "mocha --timeout 10000 --require @babel/register --exit",
     "start": "nodemon --exec babel-node src/index.js",
     "dist": "./node_modules/.bin/babel src -d dist",
     "prepublishOnly": "npm run dist",

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -42,6 +42,7 @@ export default class Client extends EventEmitter {
       mdns: null,
       username: null,
       password: null,
+      noUriSubscribeParameter: false,
       ...options
     }
 

--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -80,7 +80,8 @@ export default class Connection extends EventEmitter {
     uri += this.options.version
 
     if (protocol === 'ws') {
-      uri += '/stream?subscribe=none'
+      let uriSubscribeParameter = (this.options.noUriSubscribeParameter) ? '' : '?subscribe=none'
+      uri += '/stream' + uriSubscribeParameter
     }
 
     if (protocol === 'http') {
@@ -231,8 +232,12 @@ export default class Connection extends EventEmitter {
   }
 
   _onWSOpen () {
+    debug('[_onWSOpen] called with wsURI:', this.wsURI)
     this.connected = true
     this.isConnecting = false
+    if (this.options.noUriSubscribeParameter) {
+      this.send('{"context": "*","unsubscribe": [{"path": "*"}]}')
+    }
     this.emit('connect')
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -488,6 +488,38 @@ describe('Signal K SDK', () => {
         .catch(err => done(err))
     }).timeout(30000)
 
+// this not checking if parameter is really removed from the uri, test only if process is fonctional 
+    it('... Creates a subscription with noUriSubscribeParameter: true', done => {
+      const client = new Client({
+        hostname: 'demo.signalk.org',
+        port: 80,
+        useTLS: false,
+        reconnect: false,
+        notifications: false,
+        noUriSubscribeParameter: true,
+        bearerTokenPrefix: BEARER_TOKEN_PREFIX
+      })
+
+      let isDone = false
+
+      client.on('delta', data => {
+        assert(
+          data && typeof data === 'object' && data.hasOwnProperty('updates')
+        )
+        if (isDone === false) {
+          done()
+          isDone = true
+        }
+      })
+
+      client
+        .connect()
+        .then(() => {
+          return client.subscribe()
+        })
+        .catch(err => done(err))
+    }).timeout(30000)
+
     it('... Stops receiving data after unsubscription', done => {
       const client = new Client({
         hostname: 'demo.signalk.org',


### PR DESCRIPTION
iKommunicate does not support `?subscrime=none` parameter in URI
The new `noUriSubscribeParameter` parameter, if set to `true`, allows not to send the string `subscribe=none` without loosing functionality.
It defaults to `false`.