### PR TITLE
fix: safe values array iteration

### DIFF
--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -340,7 +340,7 @@ class Client extends _eventemitter.default {
 
     const notifications = {};
     delta.updates.forEach(update => {
-      update.values.forEach(mut => {
+      (update.values || []).forEach(mut => {
         if (typeof mut.path === 'string' && mut.path.includes('notifications.')) {
           notifications[mut.path.replace('notifications.', '')] = _objectSpread({}, mut.value);
         }

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -352,7 +352,7 @@ export default class Client extends EventEmitter {
     const notifications = {}
 
     delta.updates.forEach((update) => {
-      update.values.forEach((mut) => {
+      (update.values || []).forEach((mut) => {
         if (typeof mut.path === 'string' && mut.path.includes('notifications.')) {
           notifications[mut.path.replace('notifications.', '')] = {
             ...mut.value,


### PR DESCRIPTION
A delta may be missing values if it is a meta delta, so add a
check that values array is there before iterating over it.