### PR TITLE
Add option to get META updates in WS

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ client = new Client({
   // - "all" provides a stream of all data for all vessels
   // - "none" provides no data over the stream
   deltaStreamBehaviour: 'self',
+  // Either "all" or null.
+  // - null: provides no Meta data over the stream
+  // - "all" include Meta data of all data for all vessels
+  sendMeta: 'all',
 })
 
 // 2. Subscribe to specific Signal K paths

--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -23,6 +23,10 @@ export const SUPPORTED_STREAM_BEHAVIOUR = {
   none: 'none',
 }
 
+export const SUPPORTED_SEND_META = {
+  all: 'all',
+}
+
 export default class Connection extends EventEmitter {
   constructor(options, subscriptions = []) {
     super()
@@ -86,7 +90,7 @@ export default class Connection extends EventEmitter {
   }
 
   buildURI(protocol) {
-    const { useTLS, hostname, port, version, deltaStreamBehaviour } = this.options
+    const { useTLS, hostname, port, version, deltaStreamBehaviour, sendMeta } = this.options
 
     let uri = useTLS === true ? `${protocol}s://` : `${protocol}://`
     uri += hostname
@@ -98,8 +102,15 @@ export default class Connection extends EventEmitter {
     if (protocol === 'ws') {
       uri += '/stream'
 
+      const params = []
       if (deltaStreamBehaviour && SUPPORTED_STREAM_BEHAVIOUR.hasOwnProperty(deltaStreamBehaviour) && SUPPORTED_STREAM_BEHAVIOUR[deltaStreamBehaviour] !== '') {
-        uri += `?subscribe=${SUPPORTED_STREAM_BEHAVIOUR[deltaStreamBehaviour]}`
+        params.push(`subscribe=${SUPPORTED_STREAM_BEHAVIOUR[deltaStreamBehaviour]}`)
+      }
+      if (sendMeta && SUPPORTED_SEND_META.hasOwnProperty(sendMeta) && SUPPORTED_SEND_META[sendMeta] !== '') {
+        params.push(`sendMeta=${SUPPORTED_SEND_META[sendMeta]}`)
+      }
+      if (params) {
+        uri += '?' + params.join('&')
       }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -873,6 +873,45 @@ describe('Signal K SDK', () => {
     }).timeout(60000)
   })
 
+  describe('Metadata', () => {
+    it('... Connects and receives metadata', (done) => {
+      const clientId = uuid()
+      const client = new Client({
+        hostname: 'demo.signalk.org',
+        port: 80,
+        useTLS: false,
+        reconnect: false,
+        notifications: false,
+        bearerTokenPrefix: BEARER_TOKEN_PREFIX,
+        deltaStreamBehaviour: 'self',
+        sendMeta: 'all',
+      })
+
+      let count = 0
+      let isDone = false;
+      let timeout = setTimeout(() => {
+        assert(count > 1, 'No Metadata received')
+      }, 3000)
+
+      client.on('delta', (data) => {
+        assert(data && typeof data === 'object' && data.hasOwnProperty('updates'))
+        if (data && typeof data === 'object' && Array.isArray(data.updates)) {
+          data.updates.forEach((update) => {
+            if(update.hasOwnProperty('meta') && Array.isArray(update.meta)) {
+              count += 1;
+            }
+          })
+          if(count > 0 && !isDone) {
+            isDone = true
+            done()
+          }
+        }
+      })
+
+      client.connect().catch((err) => done(err))
+    }).timeout(60000)
+  })
+
   describe('REST API', () => {
     let client
 


### PR DESCRIPTION
Add an option to add a 'sendMeta=all' parameter in websocket URL. This is mandatory to get META update on websocket connection.