### PR TITLE
feature: add keepalive option in WS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ const defaults = {
   username: null,
   password: null,
   deltaStreamBehaviour: 'none',
+  pingEnable: false,
+  pingInterval: 30,
 }
 
 // Instantiate client

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ const defaults = {
   username: null,
   password: null,
   deltaStreamBehaviour: 'none',
-  pingEnable: false,
-  pingInterval: 30,
+  wsKeepaliveInterval: 0
 }
 
 // Instantiate client
@@ -100,6 +99,9 @@ client = new Client({
   // - null: provides no Meta data over the stream
   // - "all" include Meta data of all data for all vessels
   sendMeta: 'all',
+  // Sends an empty message to the websocket every 10 seconds when the client does not receive any more update from the server to detect if the socket is dead.
+  wsKeepaliveInterval: 10
+
 })
 
 // 2. Subscribe to specific Signal K paths

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -42,8 +42,7 @@ export default class Client extends EventEmitter {
       password: null,
       deltaStreamBehaviour: 'none',
       subscriptions: [],
-      pingEnable: false,
-      pingInterval: 30,
+      wsKeepaliveInterval: 0,
       ...options,
     }
 

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -42,6 +42,8 @@ export default class Client extends EventEmitter {
       password: null,
       deltaStreamBehaviour: 'none',
       subscriptions: [],
+      pingEnable: false,
+      pingInterval: 30,
       ...options,
     }
 

--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -38,6 +38,7 @@ export default class Connection extends EventEmitter {
     this.socket = null
     this.lastMessage = -1
     this.isConnecting = false
+    this.wsKeepaliveIntervalMs = this.options.wsKeepaliveInterval * 1000
 
     this._fetchReady = false
     this._bearerTokenPrefix = this.options.bearerTokenPrefix || 'Bearer'
@@ -47,7 +48,7 @@ export default class Connection extends EventEmitter {
     this._self = ''
     this._subscriptions = subscriptions
 
-    this.sendPing = this.sendPing.bind(this)
+    this.keepalivedAndReschedule = this.keepalivedAndReschedule.bind(this)
     this.onWSMessage = this._onWSMessage.bind(this)
     this.onWSOpen = this._onWSOpen.bind(this)
     this.onWSClose = this._onWSClose.bind(this)
@@ -271,10 +272,12 @@ export default class Connection extends EventEmitter {
     this.removeAllListeners()
   }
 
-  sendPing() {
+  keepalivedAndReschedule() {
     if (this.connected === true) {
-      this.socket.ping("");
-      setTimeout(this.sendPing, this.options.pingInterval * 1000);
+      if (this.lastMessage < Date.now() - this.wsKeepaliveIntervalMs) {
+        this.socket.send("{}");
+      }
+      setTimeout(this.keepalivedAndReschedule, this.wsKeepaliveIntervalMs);
     }
   }
 
@@ -307,7 +310,7 @@ export default class Connection extends EventEmitter {
     }
 
     this._retries = 0
-    if(this.options.pingEnable) this.sendPing();
+    if(this.options.wsKeepaliveInterval > 0) this.keepalivedAndReschedule();
     this.emit('connect')
   }
 

--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -47,6 +47,7 @@ export default class Connection extends EventEmitter {
     this._self = ''
     this._subscriptions = subscriptions
 
+    this.sendPing = this.sendPing.bind(this)
     this.onWSMessage = this._onWSMessage.bind(this)
     this.onWSOpen = this._onWSOpen.bind(this)
     this.onWSClose = this._onWSClose.bind(this)
@@ -270,6 +271,13 @@ export default class Connection extends EventEmitter {
     this.removeAllListeners()
   }
 
+  sendPing() {
+    if (this.connected === true) {
+      this.socket.ping("");
+      setTimeout(this.sendPing, this.options.pingInterval * 1000);
+    }
+  }
+
   _onWSMessage(evt) {
     this.lastMessage = Date.now()
     let data = evt.data
@@ -299,6 +307,7 @@ export default class Connection extends EventEmitter {
     }
 
     this._retries = 0
+    if(this.options.pingEnable) this.sendPing();
     this.emit('connect')
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -835,7 +835,66 @@ describe('Signal K SDK', () => {
 
       client.connect().catch((err) => done(err))
     }).timeout(20000)
+
+    it('... Send ping in WS every 1s and wait for 10 delta update "navigation.datetime"', (done) => {
+      const client = new Client({
+        hostname: 'demo.signalk.org',
+        port: 80,
+        useTLS: false,
+        reconnect: false,
+        notifications: false,
+        bearerTokenPrefix: BEARER_TOKEN_PREFIX,
+        deltaStreamBehaviour: 'none',
+        pingEnable: true,
+        pingInterval: 1
+      })
+
+      let count = 0
+
+      client.on('connect', () => {
+        client.subscribe({
+          context: 'vessels.self',
+          subscribe: [
+            {
+              path: 'navigation.datetime',
+              policy: 'instant',
+            },
+          ],
+        })
+      })
+
+      client.on('delta', (data) => {
+        count += 1
+
+        if (count < 10) {
+          const findPathInUpdate = (update) => {
+            if (!Array.isArray(update.values)) {
+              return false
+            }
+
+            const found = update.values.find((mut) => mut.path === 'navigation.datetime')
+            return found && typeof found === 'object'
+          }
+
+          let hasPath = false
+
+          try {
+            const search = data.updates.find(findPathInUpdate)
+            hasPath = search && typeof search === 'object'
+          } catch (e) {
+            hasPath = false
+          }
+
+          assert(data && typeof data === 'object' && data.hasOwnProperty('updates') && data.hasOwnProperty('context') && hasPath && data.context === client.self)
+        } else if (count === 10) {
+          done()
+        }
+      })
+
+      client.connect().catch((err) => done(err))
+    }).timeout(20000)
   })
+
 
   describe('Notifications', () => {
     it('... Connects and receives notifications', (done) => {

--- a/test/index.js
+++ b/test/index.js
@@ -836,7 +836,7 @@ describe('Signal K SDK', () => {
       client.connect().catch((err) => done(err))
     }).timeout(20000)
 
-    it('... Send ping in WS every 1s and wait for 10 delta update "navigation.datetime"', (done) => {
+    it('... Send keepalived in WS every 0.5s and wait for 10 delta update "navigation.datetime"', (done) => {
       const client = new Client({
         hostname: 'demo.signalk.org',
         port: 80,
@@ -845,8 +845,7 @@ describe('Signal K SDK', () => {
         notifications: false,
         bearerTokenPrefix: BEARER_TOKEN_PREFIX,
         deltaStreamBehaviour: 'none',
-        pingEnable: true,
-        pingInterval: 1
+        wsKeepaliveInterval: 0.5
       })
 
       let count = 0


### PR DESCRIPTION
Added `wsKeepaliveInterval` option to send an empty message to the websocket every X seconds when the client does not receive any more update from the server to detect if the socket is dead.